### PR TITLE
feat(nba_stats): add OREB and RPG to the  player comparison dropdown

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ Here are the amazing individuals who have contributed to this project:
 - [Cecilia Tivir](https://github.com/ctivir)🏀
 - [Vanessa Mohr](https://github.com/vanessamohr)🏀
 - [Kopano Mashaba](https://github.com/Skoperrr) 🏀
+- [Eusébio Simango](https://github.com/EusebioSimango) 🏀

--- a/nba_stats/forms.py
+++ b/nba_stats/forms.py
@@ -38,6 +38,8 @@ COMP_OPTIONS = (
     ('FT_PCT', 'Free Throw %'),
     ('FTA', 'Free Throw Attempts'),
     ('FTM', 'Free Throws Made'),
+    ('RPG', 'Rebs Per Game'),
+    ('OREB', 'Offensive Rebounds')
 )
 
 GRAPH_OPTIONS = (


### PR DESCRIPTION
This PR closes issue #7 

## Screenshots

### RPG Graph

<img width="1511" height="1038" alt="image" src="https://github.com/user-attachments/assets/3aebb2f8-fbfb-4540-b0e3-1761bb783138" />

### OREB Graph

<img width="1661" height="1031" alt="image" src="https://github.com/user-attachments/assets/32dc7060-9edd-4966-8710-e7f95d8eae00" />
